### PR TITLE
feat: export current wealth account balances

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The **Credit Karma Data Extractor** exports transaction history, net worth histo
 - **Instant Stop**: Cancel huge extractions immediately without losing data—what you've fetched is saved.
 - **Smart Export**: Automatically generates `All Data`, `Income Only`, and `Expenses Only` files.
 - **Wealth History**: Export the full Net Worth and Investment graph series as separate, date-filtered CSV files.
+- **Current Wealth Accounts**: Export current cash and investment source balances to a separate `wealth_accounts_<date>.csv` snapshot. This export is not filtered by the selected historical date range.
 
 ## Quick Start
 
@@ -34,6 +35,7 @@ The **Credit Karma Data Extractor** exports transaction history, net worth histo
    - Click the extension icon.
    - Select your date range (or click "Last Year").
    - Choose the transaction and/or wealth-history files to generate.
+   - Optionally choose **Current Cash & Investment Accounts** for an as-of snapshot of the source rows currently returned by Credit Karma.
    - Click **Export Selected Data**.
    - Watch the progress indicator and wait for your CSV files!
 
@@ -46,6 +48,9 @@ Once you have your CSVs, you can use them with:
 3. Any spreadsheet software (Excel, Google Sheets, Numbers).
 
 ## Changelog
+
+### Unreleased
+- Added a separate current-balance snapshot export for individual cash and investment sources. Credit Karma's captured responses do not provide per-source history, so this file is intentionally independent of the date-range fields.
 
 ### Version 2.1 (July 2026)
 - Added separate CSV exports for Net Worth and Investment graph values.

--- a/content.js
+++ b/content.js
@@ -204,6 +204,107 @@ function formattedTextValue(formattedText) {
     return formattedText?.spans?.map(span => span.text || '').join('').trim() || '';
 }
 
+function viewTextValue(value) {
+    if (typeof value === 'string' || typeof value === 'number') {
+        return String(value).trim();
+    }
+    return formattedTextValue(value);
+}
+
+function parseFormattedBalance(value) {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+
+    const text = viewTextValue(value);
+    if (!text || text.includes('%')) return null;
+
+    const normalized = text
+        .replace(/[\u2212\u2012\u2013\u2014]/g, '-')
+        .replace(/\s/g, '');
+    const isNegative = /^\(.*\)$/.test(normalized) || normalized.includes('-');
+    const numericText = normalized.replace(/[(),+$¢£¥€-]/g, '');
+
+    if (!/^\d+(?:\.\d+)?$/.test(numericText)) return null;
+
+    const parsed = Number(numericText);
+    if (!Number.isFinite(parsed)) return null;
+    return isNegative ? -parsed : parsed;
+}
+
+function formatSnapshotDate(date) {
+    if (!date || typeof date.getTime !== 'function' || Number.isNaN(date.getTime())) {
+        throw new Error('Cannot export current account balances without a valid as-of date.');
+    }
+    return date.toISOString();
+}
+
+/**
+ * Extract current account/source balances from KPL row views. A row can be a
+ * direct view or be repeated below an experimentation view's lookalikeViews,
+ * so traverse the response and deduplicate exact account snapshots.
+ */
+function extractWealthAccountRows(data, accountType, asOf = new Date()) {
+    const root = data?.data?.prime?.networthByAccountType;
+    if (!root || typeof root !== 'object') {
+        throw new Error(`Credit Karma did not return current ${accountType} account balances. The API may have changed.`);
+    }
+
+    const rows = [];
+    const visited = new Set();
+    const asOfValue = formatSnapshotDate(asOf);
+
+    function visit(value) {
+        if (!value || typeof value !== 'object' || visited.has(value)) return;
+        visited.add(value);
+
+        if (!Array.isArray(value) && value.rowTitle && value.rowValue) {
+            const sourceLabel = viewTextValue(value.rowTitle);
+            const balance = parseFormattedBalance(value.rowValue);
+            const descriptor = viewTextValue(
+                value.statusText
+                || value.rowStatusDot?.statusDotText
+                || value.rowSubtitle
+                || value.rowSubTitle
+                || value.descriptor
+                || value.subTitle
+            );
+
+            if (sourceLabel && balance !== null) {
+                rows.push({
+                    asOf: asOfValue,
+                    accountType,
+                    sourceLabel,
+                    balance,
+                    descriptor
+                });
+            }
+        }
+
+        for (const child of Object.values(value)) {
+            visit(child);
+        }
+    }
+
+    visit(root);
+
+    const uniqueRows = new Map();
+    for (const row of rows) {
+        const key = [
+            row.accountType.toLowerCase(),
+            row.sourceLabel.toLowerCase(),
+            row.balance,
+            row.descriptor.toLowerCase()
+        ].join('\u0000');
+        if (!uniqueRows.has(key)) uniqueRows.set(key, row);
+    }
+
+    return Array.from(uniqueRows.values())
+        .sort((a, b) => a.accountType.localeCompare(b.accountType)
+            || a.sourceLabel.localeCompare(b.sourceLabel)
+            || a.balance - b.balance);
+}
+
 function graphDateToISO(dateLabel) {
     const parsedDate = new Date(dateLabel);
     if (Number.isNaN(parsedDate.getTime())) return null;
@@ -272,6 +373,22 @@ async function fetchGraphHistory(type, startDate, endDate, signal) {
         startDate,
         endDate
     );
+}
+
+async function fetchWealthAccountSnapshots(signal, asOf = new Date()) {
+    const accountTypes = ['cash', 'investments'];
+    const responses = await Promise.all(accountTypes.map(async accountType => ({
+        accountType,
+        data: await fetchPersistedQuery(
+            'getAccountL2Page',
+            CONFIG.ACCOUNT_L2_HASH,
+            { input: { accountType } },
+            signal
+        )
+    })));
+
+    return responses.flatMap(({ accountType, data }) =>
+        extractWealthAccountRows(data, accountType, asOf));
 }
 
 /**
@@ -1060,6 +1177,19 @@ function convertGraphHistoryToCSV(history, valueColumn) {
     return `Date,${valueColumn}\n${rows.join('')}`;
 }
 
+function convertWealthAccountsToCSV(rows) {
+    const escape = value => String(value ?? '').replace(/"/g, '""');
+    const csvRows = rows.map(row => [
+        row.asOf,
+        row.accountType,
+        row.sourceLabel,
+        row.balance,
+        row.descriptor
+    ].map(value => `"${escape(value)}"`).join(',') + '\n');
+
+    return `As Of,Account Type,Source Label,Balance,Descriptor\n${csvRows.join('')}`;
+}
+
 function saveCSVToFile(csvData, fileName) {
     const blob = new Blob([csvData], { type: 'text/csv' });
     const link = document.createElement('a');
@@ -1448,7 +1578,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         try {
             const { startDate, endDate, csvTypes, fetchAccountNames = false, useApi = true, columns } = request;
             const needsTransactions = csvTypes.allTransactions || csvTypes.income || csvTypes.expenses;
-            console.log(`Received export request from ${startDate} to ${endDate}`);
+            console.log(csvTypes.wealthAccounts
+                ? 'Received export request including current account balances'
+                : `Received export request from ${startDate} to ${endDate}`);
 
             // Create a visual indicator that extraction is in progress - moved to left side
             const indicator = document.createElement('div');
@@ -1532,16 +1664,32 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                     );
                 }
 
-                return { transactionCount: filteredTransactions.length, graphResults };
+                let wealthAccountCount = 0;
+                if (csvTypes.wealthAccounts) {
+                    const asOf = new Date();
+                    const wealthAccounts = await fetchWealthAccountSnapshots(undefined, asOf);
+                    wealthAccountCount = wealthAccounts.length;
+                    if (wealthAccountCount === 0) {
+                        console.warn('No current cash or investment account balances were found.');
+                    } else {
+                        saveCSVToFile(
+                            convertWealthAccountsToCSV(wealthAccounts),
+                            `wealth_accounts_${asOf.toISOString().slice(0, 10)}.csv`
+                        );
+                    }
+                }
+
+                return { transactionCount: filteredTransactions.length, graphResults, wealthAccountCount };
             };
 
-            exportData().then(({ transactionCount, graphResults }) => {
+            exportData().then(({ transactionCount, graphResults, wealthAccountCount }) => {
                 if (indicator.parentNode) indicator.parentNode.removeChild(indicator);
 
                 const graphPointCount = graphResults.reduce((count, result) => count + result.history.length, 0);
                 const summaryParts = [];
                 if (needsTransactions) summaryParts.push(`${transactionCount} transactions`);
                 if (graphResults.length) summaryParts.push(`${graphPointCount} graph values`);
+                if (csvTypes.wealthAccounts) summaryParts.push(`${wealthAccountCount} current account balances`);
 
                 // Show completion notification - moved to left side
                 const completionNotice = document.createElement('div');

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Credit Karma Data Exporter",
   "version": "2.1",
-  "description": "Export transactions, net worth history, and investment values from Credit Karma.",
+  "description": "Export transactions, wealth history, and current account balances from Credit Karma.",
   "permissions": [
     "activeTab",
     "scripting"

--- a/popup.css
+++ b/popup.css
@@ -182,6 +182,19 @@ input[type="date"] {
   margin: 0;
 }
 
+.checkbox-label-wide {
+  grid-column: 1 / -1;
+  align-items: flex-start;
+}
+
+.checkbox-label-wide small {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 400;
+}
+
 /* Toggle Switch */
 .toggle-row {
   display: flex;

--- a/popup.html
+++ b/popup.html
@@ -70,6 +70,13 @@
                 <label class="checkbox-label">
                     <input type="checkbox" id="investmentsCheckbox"> Investment History
                 </label>
+                <label class="checkbox-label checkbox-label-wide">
+                    <input type="checkbox" id="wealthAccountsCheckbox">
+                    <span>
+                        Current Cash &amp; Investment Accounts
+                        <small>Current balances only; date range does not apply</small>
+                    </span>
+                </label>
             </div>
         </section>
 

--- a/popup.js
+++ b/popup.js
@@ -114,11 +114,6 @@ document.getElementById('export-btn').addEventListener('click', () => {
     const startDate = document.getElementById('start-date').value;
     const endDate = document.getElementById('end-date').value;
 
-    if (!startDate || !endDate) {
-        alert('Please select both start and end dates.');
-        return;
-    }
-
     // Get Settings
     const useApi = document.getElementById('useApiCheckbox').checked;
 
@@ -128,11 +123,19 @@ document.getElementById('export-btn').addEventListener('click', () => {
         income: document.getElementById('incomeCheckbox').checked,
         expenses: document.getElementById('expensesCheckbox').checked,
         netWorth: document.getElementById('netWorthCheckbox').checked,
-        investments: document.getElementById('investmentsCheckbox').checked
+        investments: document.getElementById('investmentsCheckbox').checked,
+        wealthAccounts: document.getElementById('wealthAccountsCheckbox').checked
     };
 
     if (!Object.values(csvTypes).some(Boolean)) {
         alert('Please select at least one file to generate.');
+        return;
+    }
+
+    const needsDateRange = Object.entries(csvTypes)
+        .some(([type, selected]) => type !== 'wealthAccounts' && selected);
+    if (needsDateRange && (!startDate || !endDate)) {
+        alert('Please select both start and end dates.');
         return;
     }
 

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -16,10 +16,20 @@ vm.createContext(context);
 vm.runInContext(`${contentScript}\n;globalThis.testExports = {
     extractGraphHistory,
     convertGraphHistoryToCSV,
-    graphDateToISO
+    graphDateToISO,
+    parseFormattedBalance,
+    extractWealthAccountRows,
+    convertWealthAccountsToCSV
 };`, context);
 
-const { extractGraphHistory, convertGraphHistoryToCSV, graphDateToISO } = context.testExports;
+const {
+    extractGraphHistory,
+    convertGraphHistoryToCSV,
+    graphDateToISO,
+    parseFormattedBalance,
+    extractWealthAccountRows,
+    convertWealthAccountsToCSV
+} = context.testExports;
 
 function point(date, value) {
     return {
@@ -92,5 +102,123 @@ test('graph CSV has stable headers and ISO dates', () => {
     assert.equal(
         convertGraphHistoryToCSV([{ date: '2026-07-22', value: 123.45 }], 'Net Worth'),
         'Date,Net Worth\n"2026-07-22","123.45"\n'
+    );
+});
+
+function formattedText(text) {
+    return { spans: [{ text }] };
+}
+
+function accountResponse(views) {
+    return {
+        data: {
+            prime: {
+                networthByAccountType: {
+                    cards: [{ item: { views } }]
+                }
+            }
+        }
+    };
+}
+
+function accountRow(label, balance, descriptor) {
+    return {
+        __typename: 'KPLRowView',
+        rowTitle: formattedText(label),
+        rowValue: formattedText(balance),
+        statusText: descriptor == null ? null : formattedText(descriptor)
+    };
+}
+
+test('parseFormattedBalance handles formatted, numeric, and negative values', () => {
+    assert.equal(parseFormattedBalance(formattedText('$1,234.56')), 1234.56);
+    assert.equal(parseFormattedBalance(formattedText('($45.67)')), -45.67);
+    assert.equal(parseFormattedBalance(formattedText('\u2212 $8.90')), -8.9);
+    assert.equal(parseFormattedBalance(-12.34), -12.34);
+    assert.equal(parseFormattedBalance(formattedText('$0.00')), 0);
+    assert.equal(parseFormattedBalance(formattedText('12%')), null);
+    assert.equal(parseFormattedBalance(null), null);
+});
+
+test('account snapshots include direct and nested lookalike rows and deduplicate copies', () => {
+    const direct = accountRow('Daily Cash', '$1,234.56', 'Connected');
+    const nested = accountRow('Brokerage', '$8,765.44', 'Manual account');
+    const duplicate = accountRow('Daily Cash', '$1,234.56', 'Connected');
+    const data = accountResponse([
+        nested,
+        { __typename: 'KPLExperimentationView', lookalikeViews: [duplicate] },
+        { rowTitle: formattedText('Missing balance'), rowValue: null },
+        direct
+    ]);
+    const asOf = new Date('2026-07-22T15:30:00.000Z');
+
+    const rows = extractWealthAccountRows(data, 'cash', asOf);
+
+    assert.deepEqual(JSON.parse(JSON.stringify(rows)), [
+        {
+            asOf: '2026-07-22T15:30:00.000Z',
+            accountType: 'cash',
+            sourceLabel: 'Brokerage',
+            balance: 8765.44,
+            descriptor: 'Manual account'
+        },
+        {
+            asOf: '2026-07-22T15:30:00.000Z',
+            accountType: 'cash',
+            sourceLabel: 'Daily Cash',
+            balance: 1234.56,
+            descriptor: 'Connected'
+        }
+    ]);
+});
+
+test('account snapshots tolerate reordered fields, missing descriptors, and negative balances', () => {
+    const data = accountResponse([{
+        rowValue: formattedText('-$25.00'),
+        presentationMetadata: null,
+        rowTitle: formattedText('Example Source')
+    }]);
+
+    const rows = extractWealthAccountRows(
+        data,
+        'investments',
+        new Date('2026-07-22T16:00:00.000Z')
+    );
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].sourceLabel, 'Example Source');
+    assert.equal(rows[0].balance, -25);
+    assert.equal(rows[0].descriptor, '');
+});
+
+test('account snapshots use KPL status-dot text as the descriptor', () => {
+    const data = accountResponse([{
+        rowTitle: formattedText('Example Source'),
+        rowValue: formattedText('$50.00'),
+        rowStatusDot: { statusDotText: formattedText('Needs attention') }
+    }]);
+
+    const rows = extractWealthAccountRows(data, 'cash', new Date('2026-07-22T16:00:00.000Z'));
+    assert.equal(rows[0].descriptor, 'Needs attention');
+});
+
+test('account snapshot parser rejects responses without the expected account root', () => {
+    assert.throws(
+        () => extractWealthAccountRows({}, 'cash', new Date()),
+        /did not return current cash account balances/
+    );
+});
+
+test('account CSV uses stable columns and escapes text without changing numeric balances', () => {
+    assert.equal(
+        convertWealthAccountsToCSV([{
+            asOf: '2026-07-22T15:30:00.000Z',
+            accountType: 'investments',
+            sourceLabel: 'Brokerage "A"',
+            balance: -25.5,
+            descriptor: 'Manual'
+        }]),
+        'As Of,Account Type,Source Label,Balance,Descriptor\n' +
+        '"2026-07-22T15:30:00.000Z","investments","Brokerage ""A""","-25.5","Manual"\n'
     );
 });

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -1,0 +1,118 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const popupScript = fs.readFileSync(path.join(__dirname, '..', 'popup.js'), 'utf8');
+
+function createPopupContext() {
+    const listeners = new Map();
+    const alerts = [];
+    const sentMessages = [];
+    const checkboxIds = [
+        'useApiCheckbox',
+        'allTransactionsCheckbox',
+        'incomeCheckbox',
+        'expensesCheckbox',
+        'netWorthCheckbox',
+        'investmentsCheckbox',
+        'wealthAccountsCheckbox',
+        'col-date',
+        'col-desc',
+        'col-amount',
+        'col-category',
+        'col-type',
+        'col-account',
+        'col-notes',
+        'col-labels'
+    ];
+    const elements = new Map();
+
+    function element(id) {
+        const result = {
+            id,
+            checked: false,
+            value: '',
+            textContent: id,
+            disabled: false,
+            addEventListener(type, callback) {
+                listeners.set(`${id}:${type}`, callback);
+            }
+        };
+        elements.set(id, result);
+        return result;
+    }
+
+    element('theme-toggle');
+    element('start-date');
+    element('end-date');
+    element('export-btn');
+    element('debug-raw-btn');
+    for (const id of checkboxIds) element(id);
+    elements.get('useApiCheckbox').checked = true;
+    for (const id of checkboxIds.filter(id => id.startsWith('col-'))) {
+        elements.get(id).checked = true;
+    }
+
+    const body = {
+        theme: 'light',
+        setAttribute(_name, value) { this.theme = value; },
+        getAttribute() { return this.theme; }
+    };
+    const context = {
+        URL,
+        console,
+        document: {
+            body,
+            getElementById: id => elements.get(id),
+            querySelectorAll: () => []
+        },
+        localStorage: {
+            getItem: () => null,
+            setItem() {}
+        },
+        alert: message => alerts.push(message),
+        setTimeout: callback => callback(),
+        chrome: {
+            runtime: { lastError: null },
+            scripting: { executeScript() {} },
+            tabs: {
+                query(_options, callback) {
+                    callback([{ id: 7, url: 'https://www.creditkarma.com/networth' }]);
+                },
+                sendMessage(_tabId, message, callback) {
+                    sentMessages.push(message);
+                    callback({ status: 'started' });
+                }
+            }
+        }
+    };
+
+    vm.createContext(context);
+    vm.runInContext(popupScript, context);
+    return { alerts, elements, listeners, sentMessages };
+}
+
+test('current wealth account snapshots can export without a historical date range', () => {
+    const { alerts, elements, listeners, sentMessages } = createPopupContext();
+    elements.get('wealthAccountsCheckbox').checked = true;
+
+    listeners.get('export-btn:click')();
+
+    assert.deepEqual(alerts, []);
+    assert.equal(sentMessages.length, 1);
+    assert.equal(sentMessages[0].csvTypes.wealthAccounts, true);
+    assert.equal(sentMessages[0].startDate, '');
+    assert.equal(sentMessages[0].endDate, '');
+});
+
+test('historical exports still require both dates', () => {
+    const { alerts, elements, listeners, sentMessages } = createPopupContext();
+    elements.get('netWorthCheckbox').checked = true;
+
+    listeners.get('export-btn:click')();
+
+    assert.deepEqual(alerts, ['Please select both start and end dates.']);
+    assert.deepEqual(sentMessages, []);
+});


### PR DESCRIPTION
## Summary

- add a separate wealth_accounts_<date>.csv export for current cash and investment source balances
- parse direct KPL account rows and copies nested under lookalikeViews
- preserve the existing date-filtered net-worth and investment history CSV formats
- make the popup explicit that current account balances do not use the selected historical date range

## Implementation

The new CSV has stable columns: As Of, Account Type, Source Label, Balance, and Descriptor. The parser handles formatted currency, negative values, zero balances, missing descriptors, reordered fields, and duplicate direct/lookalike rows. Tests use synthetic fixtures only.

## Limitations

- The captured response shapes expose source rows only for cash and investments.
- The captured responses do not expose historical values for each source, so this is an as-of snapshot rather than per-source history.
- Credit Karma does not provide a reliable institution/provider field in these rows.

## Validation

- node --check background.js
- node --check content.js
- node --check popup.js
- node --test (14 passing)
- packaged-extension archive integrity check with git archive and unzip -t
- git diff --check

## AI assistance

This pull request was materially assisted by OpenAI Codex. Codex implemented the changes and ran the automated checks listed above. No manual testing by a human has been performed, including loading the unpacked extension against a live Credit Karma account; maintainer review and live validation are still required.